### PR TITLE
make the color pair types always align with pancurses methods

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,10 +1,16 @@
 use pancurses::{Window, COLOR_PAIR};
 
-pub const REGULAR_PAIR: u64 = 0;
-pub const HIGHLIGHT_PAIR: u64 = 1;
-pub const TITLE_PAIR: u64 = 2;
-pub const INFO_PAIR: u64 = 3;
-pub const UNIQUE_PAIR: u64 = 4;
+#[cfg(target_family = "windows")]
+pub type PairType = u64;
+
+#[cfg(target_family = "unix")]
+pub type PairType = u32;
+
+pub const REGULAR_PAIR: PairType = 0;
+pub const HIGHLIGHT_PAIR: PairType = 1;
+pub const TITLE_PAIR: PairType = 2;
+pub const INFO_PAIR: PairType = 3;
+pub const UNIQUE_PAIR: PairType = 4;
 
 #[derive(Default)]
 pub(crate) struct UI {
@@ -24,7 +30,7 @@ impl UI {
     }
 
     // prints the row
-    pub fn label(&mut self, win: &Window, text: &str, pair: u64) {
+    pub fn label(&mut self, win: &Window, text: &str, pair: PairType) {
         win.mv(self.row as i32, 0);
         win.attron(COLOR_PAIR(pair));
         win.addstr(text);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,16 +1,10 @@
-use pancurses::{Window, COLOR_PAIR};
+use pancurses::{chtype, Window, COLOR_PAIR};
 
-#[cfg(target_family = "windows")]
-pub type PairType = u64;
-
-#[cfg(target_family = "unix")]
-pub type PairType = u32;
-
-pub const REGULAR_PAIR: PairType = 0;
-pub const HIGHLIGHT_PAIR: PairType = 1;
-pub const TITLE_PAIR: PairType = 2;
-pub const INFO_PAIR: PairType = 3;
-pub const UNIQUE_PAIR: PairType = 4;
+pub const REGULAR_PAIR: chtype = 0;
+pub const HIGHLIGHT_PAIR: chtype = 1;
+pub const TITLE_PAIR: chtype = 2;
+pub const INFO_PAIR: chtype = 3;
+pub const UNIQUE_PAIR: chtype = 4;
 
 #[derive(Default)]
 pub(crate) struct UI {
@@ -30,7 +24,7 @@ impl UI {
     }
 
     // prints the row
-    pub fn label(&mut self, win: &Window, text: &str, pair: PairType) {
+    pub fn label(&mut self, win: &Window, text: &str, pair: chtype) {
         win.mv(self.row as i32, 0);
         win.attron(COLOR_PAIR(pair));
         win.addstr(text);


### PR DESCRIPTION
I was getting this error on linux: 
```Rust
// rusted-tasks src/ui.rs 
pub fn label(&mut self, win: &Window, text: &str, pair: u64) {
    win.mv(self.row as i32, 0);
    win.attron(COLOR_PAIR(pair));
                ---------- ^^^^ expected `u32`, found `u64`
                arguments to this function are incorrect

    win.addstr(text);

    win.attroff(COLOR_PAIR(pair));
                ---------- ^^^^ expected `u32`, found `u64`
                arguments to this function are incorrect

    self.row += 1;
}
```
But after reading the source code of pancurses I realized the bug.
The method `attron`  and `COLOR_PAIR` takes the type of `chtype`  
```rust
// pancurses src/window.rs 
/// Turns on the named attributes without affecting any other attributes.
pub fn attron<T: Into<chtype>>(&self, attributes: T) -> i32 {
    platform_specific::_attron(self._window, attributes.into())
}

// src/unix/constants
pub fn COLOR_PAIR(n: chtype) -> attr_t {
    ncurses::COLOR_PAIR(n as i16)
}
```
And `chtype` can change depending on `#[cfg(feature="wide_chtype")]` causing the error because the pair type was previously hard coded to u64.
To avoid this issue we can import chtype from pancurses
```rust
// pancurses src/ll.rs 
/* Intrinsic types. */
#[cfg(feature="wide_chtype")]
pub type chtype = u64;

#[cfg(not(feature="wide_chtype"))]
pub type chtype = u32;
```
This will fix pancurse methods expecting the wrong value for the chtype
(chtype is u64 or u32 depending on the OS)  
```rust
use pancurses::chtype;
pub const REGULAR_PAIR: chtype = 0;
pub const HIGHLIGHT_PAIR: chtype = 1;
pub const TITLE_PAIR: chtype = 2;
pub const INFO_PAIR: chtype = 3;
pub const UNIQUE_PAIR: chtype = 4;
```